### PR TITLE
Support for latest Godot

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="CompilerConfiguration">
+    <bytecodeTargetLevel target="11" />
+  </component>
+</project>

--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -4,10 +4,10 @@
   <component name="GradleSettings">
     <option name="linkedExternalProjectsSettings">
       <GradleProjectSettings>
-        <option name="testRunner" value="PLATFORM" />
+        <option name="testRunner" value="GRADLE" />
         <option name="distributionType" value="DEFAULT_WRAPPED" />
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
-        <option name="gradleJvm" value="JDK" />
+        <option name="gradleJvm" value="1.8" />
         <option name="modules">
           <set>
             <option value="$PROJECT_DIR$" />
@@ -16,7 +16,6 @@
             <option value="$PROJECT_DIR$/godot-lib.release" />
           </set>
         </option>
-        <option name="resolveModulePerSourceSet" value="false" />
       </GradleProjectSettings>
     </option>
   </component>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_7" project-jdk-name="JDK" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_11" project-jdk-name="11" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/README.md
+++ b/README.md
@@ -6,14 +6,12 @@ This is Android Facebook plugin for Godot 3.2.2 or higher.
 * Go to Releases (on the right of this repository page) and download a released version. It is a ZIP file containing 2 files: "aar" of the plugin and "gdap" file describing it,
 * Extract the contents of the released ZIP file to res://android/plugins directory of your Godot project
 * Create "res/values" folder to your Godot project under the folder: res://android/build.
-* In the "res://android/build/res/values" folder create a new file named: strings.xml and make sure to properly set your facebook app id:
+* In "res://android/build/AndroidManifest.xml", add the following lines *inside the application section*
     ```
-        <?xml version='1.0' encoding='UTF-8'?>
-        <resources>
-          <string name="facebook_app_id">12345..</string>
-          <string name="fb_login_protocol_scheme">fb12345..</string>
-        </resources>
+        <meta-data android:name="com.facebook.sdk.ApplicationId" android:value="fb12345..."/>
+        <meta-data android:name="com.facebook.sdk.ClientToken" android:value="fb12345..."/>
     ```
+    (Replace `12345...` with your own app id. Make sure to keep the `fb` prefix)
 * On Godot platform choose: Project -> Export -> Options and make sure turn on the "Use Custom Build" and "Godot Facebook" on the "Plugins" section:
 ![Annotation 2020-07-24 121927](https://user-images.githubusercontent.com/3739222/88377830-8c48c300-cda8-11ea-8cf1-638bb1c230ee.png)
 

--- a/facebook-plugin/src/main/AndroidManifest.xml
+++ b/facebook-plugin/src/main/AndroidManifest.xml
@@ -7,13 +7,19 @@
             android:name="org.godotengine.plugin.v1.GodotFacebook"
             android:value="com.bashan.godot.facebook.GodotFacebook" />
 
-        <meta-data android:name="com.facebook.sdk.ApplicationId"
-            android:value="@string/facebook_app_id"/>
+<!--        <meta-data android:name="com.facebook.sdk.ApplicationId" android:value="@string/facebook_app_id"/>-->
+<!--        <meta-data android:name="com.facebook.sdk.ClientToken" android:value="@string/facebook_client_token"/>-->
+        <meta-data android:name="com.facebook.sdk.AutoLogAppEventsEnabled"
+            android:value="true"/>
+        <meta-data android:name="com.facebook.sdk.AdvertiserIDCollectionEnabled"
+            android:value="true"/>
 
         <activity android:name="com.facebook.FacebookActivity"
             android:configChanges=
                 "keyboard|keyboardHidden|screenLayout|screenSize|orientation"
-            android:label="@string/godot_project_name_string" />
+            android:label="Godot-Facebook-Integration" />
+
+
 
     </application>
 

--- a/facebook-plugin/src/main/java/com/bashan/godot/facebook/GodotFacebook.java
+++ b/facebook-plugin/src/main/java/com/bashan/godot/facebook/GodotFacebook.java
@@ -53,11 +53,11 @@ public class GodotFacebook extends GodotPlugin {
             public void run() {
                 try {
                     FacebookSdk.setApplicationId(key);
-                    FacebookSdk.sdkInitialize(activity.getApplicationContext());
+                    FacebookSdk.sdkInitialize(activity.getActivity().getApplicationContext());
 
                     callbackManager = CallbackManager.Factory.create();
-                    fbLogger = AppEventsLogger.newLogger(activity.getApplicationContext(), key);
-                    requestDialog = new GameRequestDialog(activity);
+                    fbLogger = AppEventsLogger.newLogger(activity.getActivity().getApplicationContext(), key);
+                    requestDialog = new GameRequestDialog(activity.getActivity());
                     requestDialog.registerCallback(callbackManager, new FacebookCallback<GameRequestDialog.Result>() {
                         public void onSuccess(GameRequestDialog.Result result) {
                             String id = result.getRequestId();


### PR DESCRIPTION
Updated to support Godot 3.5.1
I also updated a few dependencies

Since the app wouldn't build using strings.xml, I changed instructions/references so keys are added directly to the `AndroidManifest.xml`